### PR TITLE
Feature/key pair authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ENV PYTHONIOENCODING utf-8
 
 # install gcc and required libraries
 RUN apt-get update && apt-get install -y \
-    build-essential \
     git \
     libssl-dev \
     openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 ENV PYTHONIOENCODING utf-8
 
 # install gcc to be able to build packages - e.g. required by regex, dateparser, also required for pandas
-RUN apt-get update && apt-get install -y build-essential
+RUN apt-get update && apt-get install -y build-essential git
 RUN pip install flake8
 
 COPY requirements.txt /code/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM python:3.11-slim
 ENV PYTHONIOENCODING utf-8
 
-# install gcc to be able to build packages - e.g. required by regex, dateparser, also required for pandas
-RUN apt-get update && apt-get install -y build-essential git
+# install gcc and required libraries
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    libssl-dev \
+    openssl \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install flake8
 
 COPY requirements.txt /code/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
-FROM python:3.8.6-slim
+FROM python:3.11-slim
 ENV PYTHONIOENCODING utf-8
+
+# install gcc to be able to build packages - e.g. required by regex, dateparser, also required for pandas
+RUN apt-get update && apt-get install -y build-essential
+RUN pip install flake8
+
+COPY requirements.txt /code/requirements.txt
+RUN pip install -r /code/requirements.txt
 
 COPY /src /code/src/
 COPY /tests /code/tests/
 COPY /scripts /code/scripts/
-COPY requirements.txt /code/requirements.txt
 COPY flake8.cfg /code/flake8.cfg
 COPY deploy.sh /code/deploy.sh
 
-# install gcc to be able to build packages - e.g. required by regex, dateparser, also required for pandas
-RUN apt-get update && apt-get install -y build-essential && apt-get install -y git
-
-RUN pip install flake8
-
-RUN pip install -r /code/requirements.txt
-
 WORKDIR /code/
-
 
 CMD ["python", "-u", "/code/src/component.py"]

--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -22,7 +22,7 @@
           "password",
           "key_pair"
       ],
-      "default": "password",
+      "default": "key_pair",
       "options": {
           "enum_titles": [
               "Password",
@@ -40,6 +40,11 @@
       "type": "string",
       "title": "Password",
       "format": "password",
+      "options": {
+        "dependencies": {
+          "auth_type": "password"
+        }
+      },
       "propertyOrder": 130
     },
     "#private_key": {
@@ -54,7 +59,7 @@
       },
       "propertyOrder": 140
     },
-    "#private_key_passphrase": {
+    "#private_key_pass": {
         "title": "Private Key Passphrase",
         "type": "string",
         "format": "password",

--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -15,41 +15,92 @@
       "format": "password",
       "propertyOrder": 100
     },
+    "auth_type": {
+      "title": "Authentication Type",
+      "type": "string",
+      "enum": [
+          "password",
+          "key_pair"
+      ],
+      "default": "password",
+      "options": {
+          "enum_titles": [
+              "Password",
+              "Key Pair"
+          ]
+      },
+      "propertyOrder": 110
+    },
     "username": {
       "type": "string",
       "title": "User Name",
-      "propertyOrder": 110
+      "propertyOrder": 120
     },
     "#password": {
       "type": "string",
       "title": "Password",
       "format": "password",
-      "propertyOrder": 120
+      "propertyOrder": 130
+    },
+    "#private_key": {
+      "title": "Private Key",
+      "type": "string",
+      "format": "textarea",
+      "description": "Private key used for authentication",
+      "options": {
+          "dependencies": {
+            "auth_type": "key_pair"
+          }
+      },
+      "propertyOrder": 140
+    },
+    "#private_key_passphrase": {
+        "title": "Private Key Passphrase",
+        "type": "string",
+        "format": "password",
+        "description": "Passphrase for the private key",
+        "options": {
+            "dependencies": {
+              "auth_type": "key_pair"
+            }
+        },
+        "propertyOrder": 150
     },
     "account": {
       "type": "string",
       "title": "Account",
       "description": "Snowflake account, e.g. cID.eu-central-1",
-      "propertyOrder": 130
+      "propertyOrder": 160
     },
     "warehouse": {
       "type": "string",
       "title": "Warehouse",
       "description": "Snowflake Warehouse name",
-      "propertyOrder": 140
+      "propertyOrder": 170
     },
     "role": {
       "type": "string",
       "title": "Role",
       "description": "Snowflake role name. If emtpy, default role will be used.",
-      "propertyOrder": 150
+      "propertyOrder": 180
     },
     "db_name_prefix": {
       "type": "string",
       "title": "DB Name Prefix",
       "default": "KEBOOLA_",
       "description": "Keboola generated DB names are formed as {PREFIX}{PROJECT_ID}. The prefixes can differ based on BYODB deployment setup. Typically KEBOOLA_ or SAPI_",
-      "propertyOrder": 160
+      "propertyOrder": 190
+    },
+    "test_connection": {
+      "type": "button",
+      "format": "sync-action",
+      "options": {
+          "async": {
+              "label": "TEST CONNECTION",
+              "action": "testConnection"
+          }
+      },
+      "propertyOrder": 200
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 keboola.component==1.4.2
 keboola.utils
-snowflake-connector-python==3.0.0
+snowflake-connector-python==3.6.0
+cryptography>=3.1.0,<42.0.0
 git+https://github.com/keboola/sapi-python-client.git
 mock
 freezegun

--- a/src/component.py
+++ b/src/component.py
@@ -121,8 +121,9 @@ class Component(ComponentBase):
     def test_connection(self):
         try:
             self._init_configuration()
-            self._snowflake_client = snowflake_client.SnowflakeClient(
-                Credentials(
+            self._snowflake_client = snowflake_client.SnowflakeClient
+            self._snowflake_client.connect(
+                credentials_obj=Credentials(
                     account=self._configuration.account,
                     user=self._configuration.username,
                     password=self._configuration.pswd_password,
@@ -132,7 +133,6 @@ class Component(ComponentBase):
                     role=self._configuration.role
                 )
             )
-            self._snowflake_client.connect()
             return ValidationResult("Connection successful.", MessageType.SUCCESS)
 
         except snowflake_errors.Error as e:

--- a/src/component.py
+++ b/src/component.py
@@ -144,11 +144,11 @@ class Component(ComponentBase):
                     try:
                         result = client.execute_query("SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_DATABASE();")
                         return ValidationResult(
-                            f"Connection successful. Result: {result}",
+                            f"Connection successful. Test query result: {result}",
                             MessageType.SUCCESS
                         )
                     except Exception as e:
-                        return ValidationResult(f"Error during query execution: {e}", MessageType.WARNING)
+                        return ValidationResult(f"Error during test query execution: {e}", MessageType.WARNING)
 
             except Exception as conn_error:
                 return ValidationResult(f"Error during connection: {conn_error}", MessageType.WARNING)

--- a/src/component.py
+++ b/src/component.py
@@ -1,15 +1,16 @@
-'''
+"""
 Template Component main class.
 
-'''
+"""
+
 import logging
-from typing import List
 
 import snowflake.connector.errors as snowflake_errors
 from kbcstorage.client import Client
 from keboola.component.base import ComponentBase, sync_action
 from keboola.component.sync_actions import ValidationResult, MessageType
 from keboola.component.exceptions import UserException
+
 # configuration variables
 from keboola.component.sync_actions import SelectElement
 
@@ -18,11 +19,8 @@ from dbstorage import snowflake_client
 from dbstorage.snowflake_client import Credentials
 from view_creator import ViewCreator
 
-KEY_API_TOKEN = '#api_token'
-KEY_PRINT_HELLO = 'print_hello'
-KEY_PASSWORD = '#password'
-KEY_PRIVATE_KEY = '#private_key'
-KEY_PRIVATE_KEY_PASSPHRASE = '#private_key_passphrase'
+KEY_API_TOKEN = "#api_token"
+KEY_PRINT_HELLO = "print_hello"
 
 # list of mandatory parameters => if some is missing,
 # component will fail with readable message on initialization.
@@ -32,13 +30,13 @@ REQUIRED_IMAGE_PARS = []
 
 class Component(ComponentBase):
     """
-        Extends base class for general Python components. Initializes the CommonInterface
-        and performs configuration validation.
+    Extends base class for general Python components. Initializes the CommonInterface
+    and performs configuration validation.
 
-        For easier debugging the data folder is picked up by default from `../data` path,
-        relative to working directory.
+    For easier debugging the data folder is picked up by default from `../data` path,
+    relative to working directory.
 
-        If `debug` parameter is present in the `config.json`, the default logger is set to verbose DEBUG mode.
+    If `debug` parameter is present in the `config.json`, the default logger is set to verbose DEBUG mode.
     """
 
     def __init__(self):
@@ -47,12 +45,17 @@ class Component(ComponentBase):
         self._snowflake_client: snowflake_client.SnowflakeClient()
 
     def _init_configuration(self):
-        self.validate_configuration_parameters(configuration.Configuration.get_dataclass_required_parameters())
-        self._configuration: configuration.Configuration = configuration.Configuration.load_from_dict(
-            self.configuration.parameters)
+        self.validate_configuration_parameters(
+            configuration.Configuration.get_dataclass_required_parameters()
+        )
+        self._configuration: configuration.Configuration = (
+            configuration.Configuration.load_from_dict(self.configuration.parameters)
+        )
 
         if self._configuration.pswd_password and self._configuration.pswd_private_key:
-            raise UserException('Only one of password or private key should be provided.')
+            raise UserException(
+                "Only one of password or private key should be provided."
+            )
 
     def run(self):
         """
@@ -65,24 +68,30 @@ class Component(ComponentBase):
 
         # config token support
         storage_token = self._get_storage_token()
-        view_creator = ViewCreator(Credentials(account=self._configuration.account,
-                                               user=self._configuration.username,
-                                               password=self._configuration.pswd_password,
-                                               private_key=self._configuration.pswd_private_key,
-                                               private_key_pass=self._configuration.pswd_private_key_pass,
-                                               warehouse=self._configuration.warehouse,
-                                               role=self._configuration.role,
-                                               auth_type=self._configuration.auth_type),
-                                   self._get_kbc_root_url(),
-                                   storage_token,
-                                   self.environment_variables.project_id,
-                                   system_name_prefix=self._configuration.db_name_prefix)
+        view_creator = ViewCreator(
+            Credentials(
+                account=self._configuration.account,
+                user=self._configuration.username,
+                password=self._configuration.pswd_password,
+                private_key=self._configuration.pswd_private_key,
+                private_key_pass=self._configuration.pswd_private_key_pass,
+                warehouse=self._configuration.warehouse,
+                role=self._configuration.role,
+                auth_type=self._configuration.auth_type,
+            ),
+            self._get_kbc_root_url(),
+            storage_token,
+            self.environment_variables.project_id,
+            system_name_prefix=self._configuration.db_name_prefix,
+        )
 
-        additional_options = self._configuration.additional_options or configuration.AdditionalOptions()
+        additional_options = (
+            self._configuration.additional_options or configuration.AdditionalOptions()
+        )
 
         bucket_ids = self._configuration.bucket_ids
         if not bucket_ids:
-            logging.info('No buckets specified, processing all available buckets')
+            logging.info("No buckets specified, processing all available buckets")
             bucket_ids = view_creator.get_all_bucket_ids()
 
         # validate schema names, check for duplicates
@@ -90,24 +99,33 @@ class Component(ComponentBase):
         self._configuration.validate_schema_mapping(bucket_ids)
         schema_mapping = self._configuration.schema_mapping
 
-        view_creator.validate_schema_names(bucket_ids, additional_options.use_bucket_alias,
-                                           additional_options.drop_stage_prefix, schema_mapping)
+        view_creator.validate_schema_names(
+            bucket_ids,
+            additional_options.use_bucket_alias,
+            additional_options.drop_stage_prefix,
+            schema_mapping,
+        )
 
         for bucket_id in bucket_ids:
-            logging.info(f"Creating views for {bucket_id} in destination database {self._configuration.destination_db}")
-            view_creator.create_views_from_bucket(bucket_id, self._configuration.destination_db,
-                                                  column_name_case=additional_options.column_case,
-                                                  view_name_case=additional_options.view_case,
-                                                  schema_name_case=additional_options.schema_case,
-                                                  use_bucket_alias=additional_options.use_bucket_alias,
-                                                  use_table_alias=additional_options.use_table_alias,
-                                                  session_id=self.environment_variables.run_id,
-                                                  skip_shared_tables=additional_options.ignore_shared_tables,
-                                                  drop_stage_prefix=additional_options.drop_stage_prefix,
-                                                  schema_mapping=schema_mapping)
+            logging.info(
+                f"Creating views for {bucket_id} in destination database {self._configuration.destination_db}"
+            )
+            view_creator.create_views_from_bucket(
+                bucket_id,
+                self._configuration.destination_db,
+                column_name_case=additional_options.column_case,
+                view_name_case=additional_options.view_case,
+                schema_name_case=additional_options.schema_case,
+                use_bucket_alias=additional_options.use_bucket_alias,
+                use_table_alias=additional_options.use_table_alias,
+                session_id=self.environment_variables.run_id,
+                skip_shared_tables=additional_options.ignore_shared_tables,
+                drop_stage_prefix=additional_options.drop_stage_prefix,
+                schema_mapping=schema_mapping,
+            )
 
-    @sync_action('get_buckets')
-    def get_available_buckets(self) -> List[SelectElement]:
+    @sync_action("get_buckets")
+    def get_available_buckets(self) -> list[SelectElement]:
         """
         Sync action for getting list of available buckets
         Returns:
@@ -116,42 +134,57 @@ class Component(ComponentBase):
         sapi_client = Client(self._get_kbc_root_url(), self._get_storage_token())
 
         buckets = sapi_client.buckets.list()
-        return [SelectElement(value=b['id'], label=f'({b["stage"]}) {b["name"]}') for b in buckets]
+        return [
+            SelectElement(value=b["id"], label=f"({b['stage']}) {b['name']}")
+            for b in buckets
+        ]
 
     def _get_kbc_root_url(self):
-        return f'https://{self.environment_variables.stack_id}'
+        return f"https://{self.environment_variables.stack_id}"
 
     def _get_storage_token(self) -> str:
-        return self.configuration.parameters.get('#storage_token') or self.environment_variables.token
+        return (
+            self.configuration.parameters.get("#storage_token")
+            or self.environment_variables.token
+        )
 
-    @sync_action('testConnection')
+    @sync_action("testConnection")
     def test_connection(self):
         try:
             self._init_configuration()
             self._snowflake_client = snowflake_client.SnowflakeClient()
             credentials = Credentials(
-                    account=self._configuration.account,
-                    user=self._configuration.username,
-                    password=self._configuration.pswd_password,
-                    private_key=self._configuration.pswd_private_key,
-                    private_key_pass=self._configuration.pswd_private_key_pass,
-                    warehouse=self._configuration.warehouse,
-                    role=self._configuration.role,
-                    auth_type=self._configuration.auth_type
+                account=self._configuration.account,
+                user=self._configuration.username,
+                password=self._configuration.pswd_password,
+                private_key=self._configuration.pswd_private_key,
+                private_key_pass=self._configuration.pswd_private_key_pass,
+                warehouse=self._configuration.warehouse,
+                role=self._configuration.role,
+                auth_type=self._configuration.auth_type,
             )
             try:
-                with self._snowflake_client.connect(credentials_obj=credentials) as client:
+                with self._snowflake_client.connect(
+                    credentials_obj=credentials
+                ) as client:
                     try:
-                        result = client.execute_query("SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_DATABASE();")
+                        result = client.execute_query(
+                            "SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_DATABASE();"
+                        )
                         return ValidationResult(
                             f"Connection successful. Test query result: {result}",
-                            MessageType.SUCCESS
+                            MessageType.SUCCESS,
                         )
                     except Exception as e:
-                        return ValidationResult(f"Error during test query execution: {e}", MessageType.WARNING)
+                        return ValidationResult(
+                            f"Error during test query execution: {e}",
+                            MessageType.WARNING,
+                        )
 
             except Exception as conn_error:
-                return ValidationResult(f"Error during connection: {conn_error}", MessageType.WARNING)
+                return ValidationResult(
+                    f"Error during connection: {conn_error}", MessageType.WARNING
+                )
 
         except snowflake_errors.Error as e:
             return ValidationResult(f"Connection failed: {e}", MessageType.WARNING)

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -70,13 +70,13 @@ class Configuration(ConfigurationBase):
     account: str
     warehouse: str
     username: str
-    pswd_password: str = None
     role: str
     destination_db: str
+    bucket_ids: List[str]
+    pswd_password: str = None
     private_key: str = None
     private_key_pass: str = None
     # Row configuration
-    bucket_ids: List[str]
     additional_options: Optional[AdditionalOptions] = None
     schema_mapping: List[SchemaMapping] = dataclasses.field(default_factory=list)
     debug: bool = False

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -66,16 +66,16 @@ class SchemaMapping(ConfigurationBase):
 @dataclass
 class Configuration(ConfigurationBase):
     # Connection options
-    auth_type: str = None
-    account: str = None
-    warehouse: str = None
-    username: str = None
-    role: str = None
-    destination_db: str = None
-    bucket_ids: List[str] = None
-    pswd_password: str = None
-    private_key: str = None
-    private_key_pass: str = None
+    auth_type: str = "key_pair"
+    account: str = ''
+    warehouse: str = ''
+    username: str = ''
+    role: str = ''
+    destination_db: str = ''
+    bucket_ids: List[str] = dataclasses.field(default_factory=list)
+    pswd_password: str = ''
+    pswd_private_key: str = ''
+    pswd_private_key_pass: str = ''
     # Row configuration
     additional_options: Optional[AdditionalOptions] = None
     schema_mapping: List[SchemaMapping] = dataclasses.field(default_factory=list)

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,22 +1,20 @@
 import dataclasses
 import json
 from dataclasses import dataclass
-from typing import List, Optional
 
 import dataconf
 from keboola.component import UserException
 
 
 class ConfigurationBase:
-
     @staticmethod
     def _convert_private_value(value: str):
         return value.replace('"#', '"pswd_')
 
     @staticmethod
     def _convert_private_value_inv(value: str):
-        if value and value.startswith('pswd_'):
-            return value.replace('pswd_', '#', 1)
+        if value and value.startswith("pswd_"):
+            return value.replace("pswd_", "#", 1)
         else:
             return value
 
@@ -35,22 +33,25 @@ class ConfigurationBase:
         return dataconf.loads(json_conf, Configuration, ignore_unexpected=True)
 
     @classmethod
-    def get_dataclass_required_parameters(cls) -> List[str]:
+    def get_dataclass_required_parameters(cls) -> list[str]:
         """
         Return list of required parameters based on the dataclass definition (no default value)
         Returns: List[str]
 
         """
-        return [cls._convert_private_value_inv(f.name) for f in dataclasses.fields(cls)
-                if f.default == dataclasses.MISSING
-                and f.default_factory == dataclasses.MISSING]
+        return [
+            cls._convert_private_value_inv(f.name)
+            for f in dataclasses.fields(cls)
+            if f.default == dataclasses.MISSING
+            and f.default_factory == dataclasses.MISSING
+        ]
 
 
 @dataclass
 class AdditionalOptions(ConfigurationBase):
-    column_case: str = 'original'
-    view_case: str = 'original'
-    schema_case: str = 'original'
+    column_case: str = "original"
+    view_case: str = "original"
+    schema_case: str = "original"
     use_bucket_alias: bool = True
     drop_stage_prefix: bool = False
     use_table_alias: bool = False
@@ -67,23 +68,23 @@ class SchemaMapping(ConfigurationBase):
 class Configuration(ConfigurationBase):
     # Connection options
     auth_type: str = "key_pair"
-    account: str = ''
-    warehouse: str = ''
-    username: str = ''
-    role: str = ''
-    destination_db: str = ''
-    bucket_ids: List[str] = dataclasses.field(default_factory=list)
-    pswd_password: str = ''
-    pswd_private_key: str = ''
-    pswd_private_key_pass: str = ''
+    account: str = ""
+    warehouse: str = ""
+    username: str = ""
+    role: str = ""
+    destination_db: str = ""
+    bucket_ids: list[str] = dataclasses.field(default_factory=list)
+    pswd_password: str = ""
+    pswd_private_key: str = ""
+    pswd_private_key_pass: str = ""
     # Row configuration
-    additional_options: Optional[AdditionalOptions] = None
-    schema_mapping: List[SchemaMapping] = dataclasses.field(default_factory=list)
+    additional_options: AdditionalOptions | None = None
+    schema_mapping: list[SchemaMapping] = dataclasses.field(default_factory=list)
     debug: bool = False
-    pswd_storage_token: str = ''
-    db_name_prefix: str = 'KEBOOLA_'
+    pswd_storage_token: str = ""
+    db_name_prefix: str = "KEBOOLA_"
 
-    def validate_schema_mapping(self, bucket_ids: List[str]):
+    def validate_schema_mapping(self, bucket_ids: list[str]):
         """
         Validates schema mapping based on provided list of valid bucket IDs
         Args:
@@ -92,7 +93,11 @@ class Configuration(ConfigurationBase):
         Returns:
 
         """
-        invalid_mapping = [m.bucket_id for m in self.schema_mapping if m.bucket_id not in bucket_ids]
+        invalid_mapping = [
+            m.bucket_id for m in self.schema_mapping if m.bucket_id not in bucket_ids
+        ]
         if self.schema_mapping and invalid_mapping:
-            raise UserException(f"Some bucket names are invalid in the schema mapping: {invalid_mapping}. "
-                                f"Please use on of the selected buckets: {bucket_ids}")
+            raise UserException(
+                f"Some bucket names are invalid in the schema mapping: {invalid_mapping}. "
+                f"Please use on of the selected buckets: {bucket_ids}"
+            )

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -66,12 +66,15 @@ class SchemaMapping(ConfigurationBase):
 @dataclass
 class Configuration(ConfigurationBase):
     # Connection options
+    auth_type: str
     account: str
     warehouse: str
     username: str
-    pswd_password: str
+    pswd_password: str = None
     role: str
     destination_db: str
+    private_key: str = None
+    private_key_pass: str = None
     # Row configuration
     bucket_ids: List[str]
     additional_options: Optional[AdditionalOptions] = None

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -66,13 +66,13 @@ class SchemaMapping(ConfigurationBase):
 @dataclass
 class Configuration(ConfigurationBase):
     # Connection options
-    auth_type: str
-    account: str
-    warehouse: str
-    username: str
-    role: str
-    destination_db: str
-    bucket_ids: List[str]
+    auth_type: str = None
+    account: str = None
+    warehouse: str = None
+    username: str = None
+    role: str = None
+    destination_db: str = None
+    bucket_ids: List[str] = None
     pswd_password: str = None
     private_key: str = None
     private_key_pass: str = None

--- a/src/dbstorage/snowflake_client.py
+++ b/src/dbstorage/snowflake_client.py
@@ -13,10 +13,10 @@ from snowflake.connector.cursor import SnowflakeCursor
 class Credentials:
     account: str
     user: str
+    warehouse: str
     password: str = None
     private_key: str = None
     private_key_passphrase: str = None
-    warehouse: str
     database: str = None
     schema: str = None
     role: str = None

--- a/src/dbstorage/snowflake_client.py
+++ b/src/dbstorage/snowflake_client.py
@@ -60,13 +60,13 @@ class SnowflakeClient:
                 session_parameters = {}
             cfg = asdict(credentials_obj)
             cfg['session_parameters'] = session_parameters
-            self.__connection = self._create_snfk_connection(**cfg)
+            self.__connection = self._create_snfk_connection(cfg, session_parameters)
             self.__cursor = self.__connection.cursor(snowflake.connector.DictCursor)
             yield self
         finally:
             self.close()
 
-    def _create_snfk_connection(self, **config):
+    def _create_snfk_connection(self, config: dict, session_parameters: dict = None):
         auth_type = config.get("auth_type", "key_pair")
         logging.info(f"Using authentication type: {auth_type}")
 
@@ -78,6 +78,9 @@ class SnowflakeClient:
                     account=config["account"],
                     database=config["database"],
                     warehouse=config["warehouse"],
+                    role=config["role"],
+                    schema=config["schema"],
+                    session_parameters=session_parameters,
                 )
                 logging.info("Snowflake connection created successfully with password authentication")
                 return connection
@@ -108,6 +111,8 @@ class SnowflakeClient:
                     private_key=private_key_der,
                     database=config.get("database", ""),
                     role=config.get("role", ""),
+                    schema=config.get("schema", ""),
+                    session_parameters=session_parameters,
                 )
                 logging.info("Snowflake connection created successfully with key_pair authentication")
                 return connection

--- a/src/dbstorage/snowflake_client.py
+++ b/src/dbstorage/snowflake_client.py
@@ -14,13 +14,13 @@ class Credentials:
     account: str
     user: str
     warehouse: str
-    password: str = ''
-    private_key: str = ''
-    private_key_pass: str = ''
-    database: str = ''
-    schema: str = ''
-    role: str = ''
-    auth_type: str = 'key_pair'
+    password: str = ""
+    private_key: str = ""
+    private_key_pass: str = ""
+    database: str = ""
+    schema: str = ""
+    role: str = ""
+    auth_type: str = "key_pair"
 
 
 class NotConnectedError(Exception):
@@ -41,8 +41,8 @@ def validate_sql_placeholders(func):
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         for a in args:
-            if isinstance(a, str) and ';' in a:
-                raise ValueError(f'Invalid SQL parameter {a}')
+            if isinstance(a, str) and ";" in a:
+                raise ValueError(f"Invalid SQL parameter {a}")
         return func(self, *args, **kwargs)
 
     return wrapper
@@ -59,7 +59,7 @@ class SnowflakeClient:
             if not session_parameters:
                 session_parameters = {}
             cfg = asdict(credentials_obj)
-            cfg['session_parameters'] = session_parameters
+            cfg["session_parameters"] = session_parameters
             self.__connection = self._create_snfk_connection(cfg, session_parameters)
             self.__cursor = self.__connection.cursor(snowflake.connector.DictCursor)
             yield self
@@ -70,7 +70,7 @@ class SnowflakeClient:
         auth_type = config.get("auth_type", "key_pair")
         logging.info(f"Using authentication type: {auth_type}")
 
-        if auth_type == 'password':
+        if auth_type == "password":
             try:
                 connection = snowflake.connector.connect(
                     user=config["user"],
@@ -82,25 +82,33 @@ class SnowflakeClient:
                     schema=config["schema"],
                     session_parameters=session_parameters,
                 )
-                logging.info("Snowflake connection created successfully with password authentication")
+                logging.info(
+                    "Snowflake connection created successfully with password authentication"
+                )
                 return connection
             except Exception as e:
-                logging.error("Failed to create Snowflake connection with password: %s", str(e))
+                logging.error(
+                    "Failed to create Snowflake connection with password: %s", str(e)
+                )
                 raise
         else:
-            private_key_pem = config["private_key"].encode('utf-8')
+            private_key_pem = config["private_key"].encode("utf-8")
             raw_passphrase = config.get("private_key_pass")
 
             if raw_passphrase:
-                passphrase = raw_passphrase.encode('utf-8')
-                private_key = serialization.load_pem_private_key(data=private_key_pem, password=passphrase)
+                passphrase = raw_passphrase.encode("utf-8")
+                private_key = serialization.load_pem_private_key(
+                    data=private_key_pem, password=passphrase
+                )
             else:
-                private_key = serialization.load_pem_private_key(data=private_key_pem, password=None)
+                private_key = serialization.load_pem_private_key(
+                    data=private_key_pem, password=None
+                )
 
             private_key_der = private_key.private_bytes(
                 encoding=serialization.Encoding.DER,
                 format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption()
+                encryption_algorithm=serialization.NoEncryption(),
             )
 
             try:
@@ -114,50 +122,68 @@ class SnowflakeClient:
                     schema=config.get("schema", ""),
                     session_parameters=session_parameters,
                 )
-                logging.info("Snowflake connection created successfully with key_pair authentication")
+                logging.info(
+                    "Snowflake connection created successfully with key_pair authentication"
+                )
                 return connection
             except Exception as e:
-                logging.error("Failed to create Snowflake connection with key_pair: %s", str(e))
+                logging.error(
+                    "Failed to create Snowflake connection with key_pair: %s", str(e)
+                )
                 raise
 
     @_check_connection
     def execute_query(self, query):
         logging.debug(f"{query}")
-        cursor = self._cursor
-        cursor.execute(query)
-        result = cursor.fetchall()
-        return result
+        self._cursor.execute(query).fetchall()
 
     @validate_sql_placeholders
-    def create_or_replace_view(self, name, columns_definition: str, source_table: str, copy_grants: bool = False):
-        copy_grants_query = ''
+    def create_or_replace_view(
+        self,
+        name,
+        columns_definition: str,
+        source_table: str,
+        copy_grants: bool = False,
+    ):
+        copy_grants_query = ""
         if copy_grants:
-            copy_grants_query = ' COPY GRANTS'
-        statement = f"CREATE OR REPLACE VIEW {name}{copy_grants_query} " \
-                    f"AS SELECT {columns_definition} FROM {source_table}"
-        logging.info(f"Creating view {name}. (Query in detail)", extra={"full_message": statement})
+            copy_grants_query = " COPY GRANTS"
+        statement = (
+            f"CREATE OR REPLACE VIEW {name}{copy_grants_query} "
+            f"AS SELECT {columns_definition} FROM {source_table}"
+        )
+        logging.info(
+            f"Creating view {name}. (Query in detail)",
+            extra={"full_message": statement},
+        )
         self.execute_query(statement)
 
     @validate_sql_placeholders
-    def create_or_replace_schema(self, database: str, schema_name: str, copy_grants: bool = False):
-        copy_grants_query = ''
+    def create_or_replace_schema(
+        self, database: str, schema_name: str, copy_grants: bool = False
+    ):
+        copy_grants_query = ""
         if copy_grants:
-            copy_grants_query = ' COPY GRANTS'
-        statement = f'CREATE OR REPLACE SCHEMA "{database}"."{schema_name}"{copy_grants_query};'
+            copy_grants_query = " COPY GRANTS"
+        statement = (
+            f'CREATE OR REPLACE SCHEMA "{database}"."{schema_name}"{copy_grants_query};'
+        )
         self.execute_query(statement)
 
     @validate_sql_placeholders
-    def create_if_not_exist_schema(self, database: str, schema_name: str, copy_grants: bool = False):
-        copy_grants_query = ''
+    def create_if_not_exist_schema(
+        self, database: str, schema_name: str, copy_grants: bool = False
+    ):
+        copy_grants_query = ""
         if copy_grants:
-            copy_grants_query = ' COPY GRANTS'
+            copy_grants_query = " COPY GRANTS"
         statement = f'CREATE SCHEMA IF NOT EXISTS "{database}"."{schema_name}"{copy_grants_query};'
         self.execute_query(statement)
 
     @validate_sql_placeholders
     @_check_connection
     def use_role(self, role: str):
-        self.execute_query(f'USE ROLE {role};')
+        self.execute_query(f"USE ROLE {role};")
 
     @property
     def _cursor(self) -> SnowflakeCursor:


### PR DESCRIPTION
### Docker and Dependencies Updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-L20): Upgraded the base image from `python:3.8.6-slim` to `python:3.11-slim`, added installation of `gcc`, `git`, `libssl-dev`, and `openssl`, and reorganized the installation steps for dependencies.

### Configuration Schema Enhancements:
* [`component_config/configSchema.json`](diffhunk://#diff-cec14640d1b418eb49c58063558e5ccb8556612a2ee0228d837b22c1953339f7R18-R108): Added a new `auth_type` field with options for `password` and `key_pair` authentication, and introduced dependencies for `password` and `private_key` fields based on the selected `auth_type`.

### Snowflake Client Integration:
* [`src/component.py`](diffhunk://#diff-55d447c5bedb7c9e39ba50bcd9d586650b9e0c4aad9371a2b5b8d9ab58391f52R8-R11): Imported new modules for Snowflake errors and validation, added new configuration keys for `password`, `private_key`, and `private_key_passphrase`, and implemented a `test_connection` sync action to validate Snowflake connections. [[1]](diffhunk://#diff-55d447c5bedb7c9e39ba50bcd9d586650b9e0c4aad9371a2b5b8d9ab58391f52R8-R11) [[2]](diffhunk://#diff-55d447c5bedb7c9e39ba50bcd9d586650b9e0c4aad9371a2b5b8d9ab58391f52R23-R25) [[3]](diffhunk://#diff-55d447c5bedb7c9e39ba50bcd9d586650b9e0c4aad9371a2b5b8d9ab58391f52R127-R161)
* [`src/configuration.py`](diffhunk://#diff-74c5b836f605d560cf50abeb6fd8714298c8bf04fc02c8be4d3eff4ba3b0f454L69-L76): Updated the `Configuration` class to include new fields for authentication type and credentials, and set default values for all fields.
* [`src/dbstorage/snowflake_client.py`](diffhunk://#diff-c2cc713b7535fb4791f9b74a26ff0099cbcefc16b24ad3417578416170bbfd95R5): Added support for both `password` and `key_pair` authentication methods in the Snowflake connection, including handling of private key serialization. [[1]](diffhunk://#diff-c2cc713b7535fb4791f9b74a26ff0099cbcefc16b24ad3417578416170bbfd95R5) [[2]](diffhunk://#diff-c2cc713b7535fb4791f9b74a26ff0099cbcefc16b24ad3417578416170bbfd95L15-R23) [[3]](diffhunk://#diff-c2cc713b7535fb4791f9b74a26ff0099cbcefc16b24ad3417578416170bbfd95L59-R129)